### PR TITLE
add 'tt'-Prefix if missing

### DIFF
--- a/scrape.go
+++ b/scrape.go
@@ -14,6 +14,9 @@ type Movie struct {
 }
 
 func FindByID(id string) (*Movie, error) {
+    if !strings.HasPrefix(id, "tt") {
+		id = "tt" + id
+	}
 	bow := surf.NewBrowser()
 	err := bow.Open(fmt.Sprintf("http://www.imdb.com/title/%s", id))
 	if err != nil {

--- a/scrape.go
+++ b/scrape.go
@@ -14,7 +14,7 @@ type Movie struct {
 }
 
 func FindByID(id string) (*Movie, error) {
-    if !strings.HasPrefix(id, "tt") {
+	if !strings.HasPrefix(id, "tt") {
 		id = "tt" + id
 	}
 	bow := surf.NewBrowser()

--- a/scrape_test.go
+++ b/scrape_test.go
@@ -12,6 +12,7 @@ func TestScrapingMovies(t *testing.T) {
 		year  string
 	}{
 		{"tt0087182", "Dune", "1984"},
+		{"0087182", "Dune", "1984"},
 		{"tt1800302", "Gold", "2016"},
 		{"tt0451279", "Wonder Woman", "2017"},
 		{"tt0071562", "The Godfather: Part II", "1974"},


### PR DESCRIPTION
According to https://github.com/cardigann/cardigann/issues/399 the scraper will prefix the imdb-id with 'tt' if it's missing. 
This will make cardigann compatible to the search-function using the torznab-request in radarr. 
Tested local, works like a charm.